### PR TITLE
refine shared memory implementation

### DIFF
--- a/src/kernels/shared_mem.cuh
+++ b/src/kernels/shared_mem.cuh
@@ -15,8 +15,8 @@ __global__ void sgemm_shared_mem_kernel(float *A, float *B, float *C, int M, int
     __shared__ float B_shared[BLOCKSIZE * BLOCKSIZE];
 
     // the inner row & col that we're accessing in this thread
-    const uint thread_row = threadIdx.x / BLOCKSIZE;
-    const uint thread_col = threadIdx.x % BLOCKSIZE;
+    const uint thread_row = threadIdx.x % BLOCKSIZE;
+    const uint thread_col = threadIdx.x / BLOCKSIZE;
 
     // advance pointers to the starting positions
     A += c_row * BLOCKSIZE * K;


### PR DESCRIPTION
测试命令
```
./sgemm 4000 3909 5987 2
```
修改前：546681 us
修改后：89676.9 us

感觉是读入shared memory的时候没有全局内存合并